### PR TITLE
Improve playback when no recordings

### DIFF
--- a/audio-guestbook.ino
+++ b/audio-guestbook.ino
@@ -401,9 +401,15 @@ void playLastRecording() {
     snprintf(filename, 11, " %05d.wav", i);
     // check, if file with index i exists
     if (!SD.exists(filename)) {
-     idx = i - 1;
-     break;
+      if (i == 0) {
+        Serial.println("No recordings found");
+        return;
       }
+      if (i > 0) {
+        idx = i - 1;
+      }
+      break;
+    }
   }
       // now play file with index idx == last recorded file
       snprintf(filename, 11, " %05d.wav", idx);


### PR DESCRIPTION
## Summary
- exit early if no recordings are found in `playLastRecording`
- avoid negative index when determining last file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688176da9dec832c8453104e69270c3e